### PR TITLE
fix: fix typo

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -66,7 +66,7 @@ const descriptions = [
 	</PageHeader>
 	<main>
 		<Section>
-			Henlo, I'm a {age} years old software engineer from Toulouse, France, who spends more time procrastinating than typing in a code
+			Henlo, I'm a {age} year old software engineer from Toulouse, France, who spends more time procrastinating than typing in a code
 			editor. While procrastinating, some of the things I do include playing games, eating cookies, challenging
 			Einstein's theory of relativity, and starting an infinite amount of side projects.
 		</Section>


### PR DESCRIPTION
Given the article before the number you must use "year" instead of "years" ^^

([https://ell.stackexchange.com/questions/133603/what-is-correct-year-old-or-years-old](https://ell.stackexchange.com/questions/133603/what-is-correct-year-old-or-years-old))
(https://blog.engram.us/how-to-use-years-old-vs-year-old-vs-year-old/)